### PR TITLE
fix bug of /project

### DIFF
--- a/src/main/java/com/datastat/dao/QueryDao.java
+++ b/src/main/java/com/datastat/dao/QueryDao.java
@@ -2787,7 +2787,6 @@ public class QueryDao {
         if (StringUtils.isBlank(projectQueryStr)) {
             return new ArrayList<>();
         }
-        projectQueryStr = "";
         ListenableFuture<Response> future = esAsyncHttpUtil.executeSearch(esUrl, queryConf.getGiteeAllIndex(), projectQueryStr);
         JsonNode dataNode = objectMapper.readTree(future.get().getResponseBody(UTF_8));
         Iterator<JsonNode> buckets = dataNode.get("aggregations").get("group_field").get("buckets").elements();


### PR DESCRIPTION
变量projectQueryStr是用于查询ES数据库的字符串。之前为了测试查询字符串为空时执行查询操作是否会报错，将projectQueryStr=“”。测试完成后没有删除projectQueryStr=“”，导致/project接口无法使用。因此删除projectQueryStr=“”。