### PR TITLE
Dockerfilemaven源换国内源

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.datastat</groupId>


### PR DESCRIPTION
上个版本改的Dockerfile构建镜像失败。在本地测试后，更改parent version为3.1.0可以成功构建镜像。