### PR TITLE
change base image to openeuler v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,17 @@ MAINTAINER zhongjun <jun.zhongjun2@gmail.com>
 RUN mkdir -p /var/lib/ds
 WORKDIR /var/lib/ds
 
-RUN apt-get update && \
-    apt-get install --yes software-properties-common
 
-RUN apt install --yes openjdk-17-jdk
-RUN apt-get install --yes wget
-RUN apt-get install --yes git
+RUN yum install -y wget \
+    && wget https://mirrors-i.tuna.tsinghua.edu.cn/Adoptium/17/jdk/x64/linux/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz \
+    && tar -zxvf OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz \
+    && wget https://mirrors.tuna.tsinghua.edu.cn/apache/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz \
+    && tar -xzvf apache-maven-3.8.8-bin.tar.gz \
+    && yum install -y git
 
-RUN wget https://mirrors.tuna.tsinghua.edu.cn/apache/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
-        tar -xzvf apache-maven-3.8.8-bin.tar.gz
+ENV JAVA_HOME=/var/lib/ds/jdk-17.0.9+9
+ENV PATH=${JAVA_HOME}/bin:$PATH
+
 ENV MAVEN_HOEM=/var/lib/ds/apache-maven-3.8.8
 ENV PATH=$MAVEN_HOEM/bin:$PATH
 ENV LANG C.UTF-8


### PR DESCRIPTION
基础镜像由ubuntu变为openeuler之后做了如下修改，能够本地成功运行镜像
1 包管理器命令由apt变为yum
2 自行指定JDK网址，自行设置JAVA_HOME
3 JDK镜像指定为清华源